### PR TITLE
Use double instead of variable for numeric constants

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -295,7 +295,7 @@ function handleParameter(params, a,  i, iOpt, str, entry)
 
   # global constants
   gsub(/\ystrconstant\y/,"const string",code)
-  gsub(/\yconstant\y/,"const variable",code)
+  gsub(/\yconstant\y/,"const double",code)
   # prevent that doxygen sees elseif as a function call
   gsub(/\yelseif\y/,"else if",code)
 


### PR DESCRIPTION
This results in fewer warnings in sphinx and is also more pleasant for
the user as double is a synonym for variable since IP7.