### PR TITLE
Ensure that the function declaration starts at the beginning of the line

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -194,7 +194,7 @@ function handleParameterNewStyle(params, a, i, iOpt, str, entry)
     code = "}"
   }
   # begin of function declaration
-  else if(!insideFunction && match(code,/function[[:space:]]*\[.*\][[:space:]]+[A-Z0-9_]+[[:space:]]*\(/))
+  else if(!insideFunction && match(code,/^((threadsafe|static|override)?[[:space:]]+)*function[[:space:]]*\[.*\][[:space:]]+[A-Z0-9_]+[[:space:]]*\(/))
   {
     insideFunction=1
 
@@ -244,7 +244,8 @@ function handleParameterNewStyle(params, a, i, iOpt, str, entry)
       code = substr(code,1,RSTART) "" paramStrWithTypes "" substr(code,RSTART+RLENGTH-1)
     }
   }
-  else if(!insideFunction && match(code,/function[[:space:]]*(\/(df|wave|c|s|t|d))?[[:space:]]+[A-Z0-9_]+[[:space:]]*\(/))
+  else if(!insideFunction && match(code,/^((threadsafe|static|override)?[[:space:]]+)*function[[:space:]]*(\/(df|wave|c|s|t|d))?[[:space:]]+[A-Z0-9_]+[[:space:]]*\(/))
+
   {
     insideFunction=1
     paramsToHandle=0

--- a/test-input-function-params.ipf
+++ b/test-input-function-params.ipf
@@ -51,3 +51,33 @@ Function [string data, string fName] myFuncParam8(string fileName[, string fileF
 
 	return ["", ""]
 End
+
+// function modifiers
+
+static Function myFuncS1()
+End
+
+static Function myFuncS2(var)
+	variable var
+End
+
+threadsafe static Function myFuncST1()
+End
+
+threadsafe static Function myFuncST2(var)
+	variable var
+End
+
+override Function myFuncSTO1()
+End
+
+override Function myFuncSTO2(var)
+	variable var
+End
+
+// and this is not a function declaration
+SomeStuff Function notAFunc()
+
+// TODO currently broken
+static Function myFuncBroken(variable var)
+End


### PR DESCRIPTION
Since forever we just did some regexp matching of the function
expression with return type and parameters.

But we need to take into account the beginning of the line as well as
code which contains a valid function declaration like

SomeStuff Function notAFunc()

is not one.

We now search for the only valid modifiers before it as well. We don't
enforce a valid subset of these though.