### PR TITLE
Fix parameter casing for inline parameters

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -200,11 +200,9 @@ function formatSingleNewStyleParameter(token, isOptional,  numElements, name, ty
   }
   else
   {
-    type = a[1]
+    type = tolower(a[1])
     name = a[2]
   }
-
-  type = tolower(type)
 
   paramLine = nicifyWaveType(type) typeSuffix " " name
 

--- a/test-input-function-params.ipf
+++ b/test-input-function-params.ipf
@@ -101,3 +101,15 @@ End
 Function/S TestWithNastyPrefix(waverefs)
 	Wave/WAVE waveRefs
 End
+
+Structure MyStruct
+	int32 count
+EndStructure
+
+Function PA_ApplyPulseSortingOrder(WAVE setIndices, STRUCT MyStruct &myStruct)
+End
+
+Function PA_GatherSettings(win, myStruct)
+	string win
+	STRUCT MyStruct &myStruct
+End

--- a/test-input-function-params.output.ref
+++ b/test-input-function-params.output.ref
@@ -86,11 +86,11 @@ variable Proto(){
 
 };
 
-variable Test1(variable a, string s, wave w, dfref d, proto f, rectf* st, int i, int64 i64, uint64 ui64, double do, complex c, variable opt = defaultValue){
+variable Test1(variable a, string s, wave w, dfref d, Proto f, RECTF* st, int i, int64 i64, uint64 ui64, double do, complex c, variable opt = defaultValue){
 
 };
 
-variable Test2(variable* a, proto f, string* s = defaultValue){
+variable Test2(variable* a, Proto f, string* s = defaultValue){
 
 };
 
@@ -100,5 +100,17 @@ variable Test3(struct* RECTF, string s = defaultValue){
 
 string TestWithNastyPrefix(WaveRefWave waverefs){
 	WaveRefWave waveRefs
+};
+
+struct MyStruct{;
+	int32 count;
+};
+
+variable PA_ApplyPulseSortingOrder(wave setIndices, MyStruct* myStruct){
+};
+
+variable PA_GatherSettings(string win, MyStruct* myStruct){
+	string win
+	STRUCT MyStruct &myStruct
 };
 


### PR DESCRIPTION
We want to lower case the type only for types which are not struct or
funcref, as otherwise the name is lowercased and that breaks doxygen
linking.

Bug introduced in e3822b47 (Support inline parameter declarations in all
cases, 2020-04-03).

Close #16.