### PR TITLE
doxygen-filter-ipf.awk: Fix parsing functions with only optional inline parameters

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -333,7 +333,7 @@ function formatSingleNewStyleParameter(token, isOptional,  numElements, name, ty
       paramsLength = RLENGTH
       paramStr = substr(code, paramsStartIndex + 1,paramsLength - 2)
 
-      if(match(paramStr, /^(variable|string|wave|dfref|funcref|struct|int|int64|uint64|double|complex)\y/))
+      if(match(paramStr, /^\[?(variable|string|wave|dfref|funcref|struct|int|int64|uint64|double|complex)\y/))
       {
         # inline parameter declaration
         paramStrWithTypes = handleParameterNewStyle(paramStr, params)

--- a/test-input-function-params.ipf
+++ b/test-input-function-params.ipf
@@ -113,3 +113,6 @@ Function PA_GatherSettings(win, myStruct)
 	string win
 	STRUCT MyStruct &myStruct
 End
+
+Function/S MyFuncWithOnlyOptionalParameters([variable channelType])
+End

--- a/test-input-function-params.output.ref
+++ b/test-input-function-params.output.ref
@@ -114,3 +114,6 @@ variable PA_GatherSettings(string win, MyStruct* myStruct){
 	STRUCT MyStruct &myStruct
 };
 
+string MyFuncWithOnlyOptionalParameters(variable channelType = defaultValue){
+};
+


### PR DESCRIPTION
We need to allow an "[" at the front of the first parameter as well.