### PR TITLE
doxygen-filter-ipf.awk: Enforce a space or start of line before a com…

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -227,7 +227,7 @@ function formatSingleNewStyleParameter(token, isOptional,  numElements, name, ty
 
 {
   # split current line into code and comment
-  if(match($0,/\/\/.*/))
+  if(match($0,/(\t| |^)\/\/.*/))
   {
     code=substr($0,1,RSTART-1)
     comment=substr($0,RSTART,RLENGTH)

--- a/test-input.ipf
+++ b/test-input.ipf
@@ -4,6 +4,9 @@ constant myConst=123 ///< This is a really special number
 /// The first alphabet letters
 strconstant myStrConst="abcd"
 
+strConstant url = "https://example.com" // test "efgh"
+strConstant someOtherUrl = "https://test.com"
+
 ///@name Functions with different return types
 ///@{
 Function FooBar()

--- a/test-input.output.ref
+++ b/test-input.output.ref
@@ -1,8 +1,11 @@
 
-const double myConst=123;///< This is a really special number
+const double myConst=123; ///< This is a really special number
 
 /// The first alphabet letters
 const string myStrConst="abcd";
+
+const string url = "https://example.com"; // test "efgh"
+const string someOtherUrl = "https://test.com";
 
 ///@name Functions with different return types
 ///@{


### PR DESCRIPTION
…ment

This makes the splitting into code and comment more robust. A long term solution would require to parse strings.

Close #29
Close #30