### PR TITLE
doxygen-filter-ipf.awk: Remove all known specifiers after include

### DIFF
--- a/doxygen-filter-ipf.awk
+++ b/doxygen-filter-ipf.awk
@@ -510,10 +510,10 @@ function formatSingleNewStyleParameter(token, isOptional,  numElements, name, ty
     code = nicifyWaveType(code)
   }
 
-  # remove menus=0 after an include statement
-  if(match(code,/^#include.*menus[[:space:]]*=[[:space:]]*0$/))
+  # remove specifiers after an include statement
+  if(match(code,/^#include.*(menus|version|optional)[[:space:]]*=?[[:space:]]*.*$/))
   {
-    gsub(/menus[[:space:]]*=[[:space:]]*0$/, "", code)
+    gsub(/,?[[:space:]]*(menus|version|optional)[[:space:]]*=?[[:space:]]*.*$/, "", code)
   }
 
   # code outside of function/macro definitions is "translated" into statements

--- a/test-input.ipf
+++ b/test-input.ipf
@@ -1,3 +1,7 @@
+#include "abcd"
+#include "efgh" menus=0
+#include "ijkl", optional
+#include "mnop", version=123, optional
 
 constant myConst=123 ///< This is a really special number
 

--- a/test-input.output.ref
+++ b/test-input.output.ref
@@ -1,3 +1,7 @@
+#include "abcd"
+#include "efgh"
+#include "ijkl"
+#include "mnop"
 
 const double myConst=123; ///< This is a really special number
 


### PR DESCRIPTION
Newer IPT versions include a comma as in

 #include "abcd", version >= 0.18

and sphinx 8.2.3 does not grok that.

We are already removing menu specifiers so let's also remove version and optional.